### PR TITLE
Echo things to figure out why deployment stage dies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,21 +163,31 @@ jobs:
           script_stop: true
           script: |
             cd /usr/src/${{ github.repository }}
+            echo "Pulling docker-stack-wait"
             docker pull sudobmitch/docker-stack-wait
+            echo "Logging in to docker"
             echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+            echo "Deploying stack"
             docker stack deploy --with-registry-auth -c docker-compose.prod.yml ${{ env.STACK_NAME }}
 
+            echo "Running docker-stack-wait"
             # Wait for deployment to complete
+            echo "Echoing after a comment"
             docker run --rm \
               -v /var/run/docker.sock:/var/run/docker.sock \
               sudobmitch/docker-stack-wait ${{ env.STACK_NAME }}
 
+            echo "Getting container id"
             # Run migrations
             # TODO: This will fail if at least one replica isn't running on the node, will need to
             # switch DOCKER_HOST over ssh
             service_id=$(docker ps -f "name=${{ env.STACK_NAME }}_django" -q | head -n1)
+            echo "Running migrations"
             docker exec $service_id python manage.py migrate
 
+            echo "Cleaning up"
             # Cleanup
             rm .env
+            echo "Logging out of docker"
             docker logout docker.pkg.github.com
+            echo "Goodbye"


### PR DESCRIPTION
Trying to figure out why our deploy stage is failing randomly. We know that execution on the server continues, the action just dies. Putting some echoes in to see if we can figure out why.

```
======END======
out: Using default tag: latest
out: latest: Pulling from sudobmitch/docker-stack-wait
out: Digest: sha256:0417d976b9aeb38a7e1dbf5d948c7d131165925178a675cd089140a655366c62
out: Status: Image is up to date for sudobmitch/docker-stack-wait:latest
out: docker.io/sudobmitch/docker-stack-wait:latest
err: WARNING! Your password will be stored unencrypted in /home/***/.docker/config.json.
err: Configure a credential helper to remove this warning. See
err: https://docs.docker.com/engine/reference/commandline/login/#credentials-store
err: 
out: Login Succeeded
out: Updating service newhacks-site-2020_django (id: vux1lttucupbma2045djo6u0h)
err: image docker.pkg.github.com/ieeeuoft/newhacks-site-2020/django:7c02f3f could not be accessed on a registry to record
err: its digest. Each node will access docker.pkg.github.com/ieeeuoft/newhacks-site-2020/django:7c02f3f independently,
err: possibly leading to different nodes running different
err: versions of the image.
err: 
2020/09/01 02:09:26 wait: remote command exited without exit status or exit signal
```