### PR TITLE
Add Redis to Deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,7 @@ jobs:
           echo 'EMAIL_HOST_USER=${{ secrets.EMAIL_HOST_USER }}' >> .env
           echo 'EMAIL_HOST_PASSWORD=${{ secrets.EMAIL_HOST_PASSWORD }}' >> .env
           echo 'EMAIL_FROM_ADDRESS=${{ secrets.EMAIL_FROM_ADDRESS }}' >> .env
+          echo 'REDIS_URI=${{ secrets.REDIS_URI }}' >> .env
       - name: Transfer static files to the Swarm manager
         uses: appleboy/scp-action@v0.1.1
         with:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -16,3 +16,22 @@ services:
         order: start-first
       restart_policy:
         condition: on-failure
+    networks:
+      - newhacks-2020
+  redis:
+    image: redis:6-alpine
+    ports:
+      - 6379:6379
+    deploy:
+      replicas: 1
+      update_config:
+        failure_action: rollback
+        order: start-first
+      restart_policy:
+        condition: on-failure
+    networks:
+      - newhacks-2020
+
+networks:
+  newhacks-2020:
+    driver: overlay


### PR DESCRIPTION
## Add Redis to Deployment
- Adds Redis to deployment
- Adds an overlay network, so that the django and redis services can communicate
- The secret `REDIS_URI` has already been created

## Unit Tests Created
- None, part of deployment

## Steps to QA
- I verified this process already on https://github.com/grahamhoyes/django-docker-swarm-example/
- Cross your fingers and hope it works
