### PR TITLE
Add resume view to urlpatterns explicitly

### DIFF
--- a/hackathon_site/hackathon_site/urls.py
+++ b/hackathon_site/hackathon_site/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
     ),
     path("registration/", include("registration.urls", namespace="registration")),
     path(
-        "^%s/applications/resumes/<str:filename>" % settings.MEDIA_URL.strip("/"),
+        "%s/applications/resumes/<str:filename>" % settings.MEDIA_URL.strip("/"),
         ResumeView.as_view(),
         name="resume",
     ),

--- a/hackathon_site/hackathon_site/urls.py
+++ b/hackathon_site/hackathon_site/urls.py
@@ -41,17 +41,12 @@ urlpatterns = [
         name="schema-swagger-ui",
     ),
     path("registration/", include("registration.urls", namespace="registration")),
+    path(
+        "^%s/applications/resumes/<str:filename>" % settings.MEDIA_URL.strip("/"),
+        ResumeView.as_view(),
+        name="resume",
+    ),
 ]
-
-if not settings.MEDIA_URL.startswith("http"):
-    urlpatterns += [
-        path(
-            "%s/applications/resumes/<str:filename>" % settings.MEDIA_URL.strip("/"),
-            ResumeView.as_view(),
-            name="resume",
-        ),
-    ]
-
 
 if settings.DEBUG:
     import debug_toolbar


### PR DESCRIPTION
## Add resume view to urlpatterns explicitly

- Resolves #68 
- Adds the resume view to the main urlpatterns explicitly
- This shouldn't change anything, but I'm hoping it does

## Unit Tests Created
- None, since in theory the behaviour shouldn't change

## Steps to QA
- Make sure resumes can still open on the admin site

